### PR TITLE
Refactor blm to allow arbitrary inference algorithms and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+*.cov
+*.jll
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,16 @@ version = "0.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]

--- a/src/BayesModels.jl
+++ b/src/BayesModels.jl
@@ -2,14 +2,11 @@ module BayesModels
 
 using Turing
 using Statistics
-using Reexport
 using LinearAlgebra
 using DataFrames
-using Optim
-import DynamicPPL
+using Reexport
+import MCMCChains
 @reexport using StatsModels
-
-export blm
 
 function get_nlogp(model)
     # Set up the model call, sample from the prior.
@@ -26,66 +23,6 @@ function get_nlogp(model)
     return nlogp
 end
 
-
-function blm(f::FormulaTerm, df::DataFrame, N::Int=1000, alpha_prior=nothing, beta_prior=nothing, sigma_prior=nothing)
-    f = apply_schema(f, schema(f, df))
-
-    # Define the default value for x when missing
-    y, X = modelcols(f, df)
-    K = size(X, 2)
-    defaults = (y = Vector{Real}(undef, 2),priors=zeros(K))
-    data = (y = y,
-            x = X)
-
-	if isnothing(alpha_prior)
-		alpha_prior = Normal()
-	end
-
-	if isnothing(beta_prior)
-		beta_prior = MvNormal(K, 1)
-	end
-
-	if isnothing(sigma_prior)
-		sigma_prior = InverseGamma(2,3)
-	end
-	
-	@model function bayesreg(
-		x, 
-		y, 
-		alpha_prior, 
-		beta_prior, 
-		sigma_prior,
-		::Type{TV}=Vector{Float64}
-	) where {TV}
-		N, K = size(x)
-
-		sigma ~ sigma_prior
-		intercept ~ alpha_prior
-		beta = TV(undef, K)
-		beta ~ beta_prior
-
-		# beta is K x 1
-		# y is N x 1
-		# x is N x K
-		yhat = intercept .+ x * beta
-
-		y ~ MvNormal(yhat, sigma)	
-	end
-
-	# Model
-	model = bayesreg(X, y, alpha_prior, beta_prior, sigma_prior)
-
-    # Sample
-    chain = sample(model, NUTS(), N)
-    
-    # Get formula names.
-    nms = coefnames(f.rhs)
-    nms_dict = Dict(["beta[$i]" => nms[i] for i in eachindex(nms)])
-
-    # Overwrite the default names.
-    chain = set_names(chain, nms_dict, sorted=false)
-
-    return chain
-end
+include("blm.jl")
 
 end # module

--- a/src/blm.jl
+++ b/src/blm.jl
@@ -22,13 +22,6 @@ should return a fitted variational distribution.
 """
 inference(::DynamicPPL.Model, strat::InferenceStrategy) = error("no inference implementation for $(typeof(strat))")
 """
-    preprocess(::InferenceStrategy, f::FormulaTerm, df::DataFrame)
-
-Applies any necessary preprocessing to the user-provided formula and DataFrame. Can be overrided for specific
-inference strategies if necessary. Should return a data tuple (y,X) representing the response and design matrix respectively.
-"""
-preprocess(::InferenceStrategy, f::FormulaTerm, df::DataFrame) = modelcols(f, df)
-"""
     postprocess(::InferenceStrategy, inferenceresult, f::FormulaTerm, df::DataFrame)
 
 Applies postprocessing to the given inference result. Returns the (possibly modified) inference result.
@@ -58,10 +51,11 @@ function blm(
     inferencestrat::InferenceStrategy=MCMC(NUTS(), 1000);
     alphaprior=nothing, 
     betaprior=nothing, 
-    sigmaprior=nothing
+    sigmaprior=nothing,
+    schemahints::Dict{Symbol}=Dict{Symbol,Any}(),
 )
-    F = apply_schema(f, schema(f, df))
-    y, X = preprocess(inferencestrat, F, df)
+    F = apply_schema(f, schema(f, df, schemahints))
+    y, X = modelcols(F, df)
     # set priors
 	alphaprior = isnothing(alphaprior) ? Normal() : alphaprior
 	betaprior = isnothing(betaprior) ? MvNormal(zeros(size(X,2)), 1) : betaprior

--- a/src/blm.jl
+++ b/src/blm.jl
@@ -52,8 +52,14 @@ end
 Fits a Bayesian linear model specified by `f` to the given data. Return value depends on the specified inference strategy.
 MCMC will return a ChainDataFrame, whereas VI will return a fitted variational distribution.
 """
-function blm(f::FormulaTerm, df::DataFrame, inferencestrat::InferenceStrategy=MCMC(NUTS(),1000);
-    alphaprior=nothing, betaprior=nothing, sigmaprior=nothing)
+function blm(
+    f::FormulaTerm,
+    df::DataFrame, 
+    inferencestrat::InferenceStrategy=MCMC(NUTS(), 1000);
+    alphaprior=nothing, 
+    betaprior=nothing, 
+    sigmaprior=nothing
+)
     F = apply_schema(f, schema(f, df))
     y, X = preprocess(inferencestrat, F, df)
     # set priors

--- a/src/blm.jl
+++ b/src/blm.jl
@@ -1,0 +1,87 @@
+abstract type InferenceStrategy end
+struct MCMC{TAlg,TArgs,TKwArgs} <: InferenceStrategy
+    nsamples::Int
+    alg::TAlg
+    algargs::TArgs
+    algkwargs::TKwArgs
+    MCMC(alg::TAlg, nsamples::Int, args...;kwargs...) where {TAlg<:Turing.InferenceAlgorithm} =
+        new{TAlg,typeof(args),typeof(kwargs)}(nsamples,alg,args,kwargs)
+end
+# TODO add VI support
+# struct VI <: InferenceStrategy end
+
+export InferenceStrategy, MCMC
+
+# Default interface methods
+"""
+    inference(::DynamicPPL.Model, strat::InferenceStrategy)
+
+Run probabilistic inference for the given model using the given InferenceStrategy (e.g. MCMC or variational inference).
+The type of the result depends on the implementation. MCMC implementations should return a ChainDataFrame, whereas VI
+should return a fitted variational distribution.
+"""
+inference(::DynamicPPL.Model, strat::InferenceStrategy) = error("no inference implementation for $(typeof(strat))")
+"""
+    preprocess(::InferenceStrategy, f::FormulaTerm, df::DataFrame)
+
+Applies any necessary preprocessing to the user-provided formula and DataFrame. Can be overrided for specific
+inference strategies if necessary. Should return a data tuple (y,X) representing the response and design matrix respectively.
+"""
+preprocess(::InferenceStrategy, f::FormulaTerm, df::DataFrame) = modelcols(f, df)
+"""
+    postprocess(::InferenceStrategy, inferenceresult, f::FormulaTerm, df::DataFrame)
+
+Applies postprocessing to the given inference result. Returns the (possibly modified) inference result.
+"""
+postprocess(::InferenceStrategy, inferenceresult, f::FormulaTerm, df::DataFrame) = inferenceresult
+
+# MCMC inference
+inference(model::DynamicPPL.Model, mcmc::MCMC) = sample(model, mcmc.alg, mcmc.nsamples, mcmc.algargs...;mcmc.algkwargs...)
+
+function postprocess(::MCMC, chain::MCMCChains.Chains, f::FormulaTerm, df::DataFrame)
+    # Get formula names.
+    nms = coefnames(f.rhs)
+    nms_dict = Dict(["β[$i]" => "β[$(nms[i])]" for i in eachindex(nms)])
+    # Overwrite the default names.
+    chain = MCMCChains.replacenames(chain, nms_dict)
+end
+
+"""
+    blm(f::FormulaTerm, df::DataFrame, inferencestrat::InferenceStrategy=MCMC(NUTS(),1000); alphaprior, betaprior, sigmaprior)
+
+Fits a Bayesian linear model specified by `f` to the given data. Return value depends on the specified inference strategy.
+MCMC will return a ChainDataFrame, whereas VI will return a fitted variational distribution.
+"""
+function blm(f::FormulaTerm, df::DataFrame, inferencestrat::InferenceStrategy=MCMC(NUTS(),1000);
+    alphaprior=nothing, betaprior=nothing, sigmaprior=nothing)
+    F = apply_schema(f, schema(f, df))
+    y, X = preprocess(inferencestrat, F, df)
+    # set priors
+	alphaprior = isnothing(alphaprior) ? Normal() : alphaprior
+	betaprior = isnothing(betaprior) ? MvNormal(zeros(size(X,2)), 1) : betaprior
+	sigmaprior = isnothing(sigmaprior) ? InverseGamma(2,3) : sigmaprior
+	@model function bayesreg(
+		x, 
+		y, 
+		alphaprior, 
+		betaprior, 
+		sigmaprior,
+	)
+        N,K = size(x)
+		σ ~ sigmaprior
+		α ~ alphaprior
+		β ~ betaprior
+		# beta is K x 1
+		# y is N x 1
+		# x is N x K
+		ŷ = α .+ x*β
+		y ~ MvNormal(ŷ, σ)
+	end
+	# Model
+	model = bayesreg(X, y, alphaprior, betaprior, sigmaprior)
+    # Sample
+    res = inference(model, inferencestrat)
+    res = postprocess(inferencestrat,res,F,df)
+end
+
+export blm

--- a/src/blm.jl
+++ b/src/blm.jl
@@ -17,7 +17,7 @@ export InferenceStrategy, MCMC
     inference(::DynamicPPL.Model, strat::InferenceStrategy)
 
 Run probabilistic inference for the given model using the given InferenceStrategy (e.g. MCMC or variational inference).
-The type of the result depends on the implementation. MCMC implementations should return a ChainDataFrame, whereas VI
+The type of the result depends on the implementation. MCMC implementations should return the sampled chains, whereas VI
 should return a fitted variational distribution.
 """
 inference(::DynamicPPL.Model, strat::InferenceStrategy) = error("no inference implementation for $(typeof(strat))")

--- a/src/blm.jl
+++ b/src/blm.jl
@@ -57,28 +57,28 @@ function blm(
     F = apply_schema(f, schema(f, df, schemahints))
     y, X = modelcols(F, df)
     # set priors
-	alphaprior = isnothing(alphaprior) ? Normal() : alphaprior
-	betaprior = isnothing(betaprior) ? MvNormal(zeros(size(X,2)), 1) : betaprior
-	sigmaprior = isnothing(sigmaprior) ? InverseGamma(2,3) : sigmaprior
-	@model function bayesreg(
-		x, 
-		y, 
-		alphaprior, 
-		betaprior, 
-		sigmaprior,
-	)
+    alphaprior = isnothing(alphaprior) ? Normal() : alphaprior
+    betaprior = isnothing(betaprior) ? MvNormal(zeros(size(X,2)), 1) : betaprior
+    sigmaprior = isnothing(sigmaprior) ? InverseGamma(2,3) : sigmaprior
+    @model function bayesreg(
+        x, 
+        y, 
+        alphaprior, 
+        betaprior, 
+        sigmaprior,
+    )
         N,K = size(x)
-		σ ~ sigmaprior
-		α ~ alphaprior
-		β ~ betaprior
-		# beta is K x 1
-		# y is N x 1
-		# x is N x K
-		ŷ = α .+ x*β
-		y ~ MvNormal(ŷ, σ)
-	end
-	# Model
-	model = bayesreg(X, y, alphaprior, betaprior, sigmaprior)
+        σ ~ sigmaprior
+        α ~ alphaprior
+        β ~ betaprior
+        # beta is K x 1
+        # y is N x 1
+        # x is N x K
+        ŷ = α .+ x*β
+        y ~ MvNormal(ŷ, σ)
+    end
+    # Model
+    model = bayesreg(X, y, alphaprior, betaprior, sigmaprior)
     # Sample
     res = inference(model, inferencestrat)
     res = postprocess(inferencestrat,res,F,df)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,35 @@
+using BayesModels
+using Turing
+using Statistics
+using RDatasets
+using Test
+
+@testset "blm" begin
+    @testset "Air Quality dataset" begin
+        data = dataset("robustbase", "airmay") |>
+        dropmissing |>
+        df -> mapcols(col -> float.(col), df) |>
+        df -> mapcols(col -> col./std(col), df)
+        chain = blm(@formula(Y ~ X1 + X2 + X3), data)
+        summary,_ = describe(chain)
+        params = summary[:,:parameters]
+        # check parameter names
+        @test Set(params) == Set([:α,Symbol("β[X1]"),Symbol("β[X2]"),Symbol("β[X3]"),:σ])
+        rhat = summary[:,:rhat]
+        # check convergence statistic
+        @test maximum(abs.(1.0 .- rhat)) <= 0.01
+    end
+    @testset "Earthquakes dataset" begin
+        data = dataset("datasets", "quakes") |>
+        df -> mapcols(col -> float.(col), df) |>
+        df -> mapcols(col -> col./std(col), df)
+        chain = blm(@formula(Mag ~ Lat + Long + Depth + Stations), data, MCMC(NUTS(),500))
+        summary,_ = describe(chain)
+        params = summary[:,:parameters]
+        # check parameter names
+        @test Set(params) == Set([:α,Symbol("β[Lat]"),Symbol("β[Long]"),Symbol("β[Depth]"),Symbol("β[Stations]"),:σ])
+        rhat = summary[:,:rhat]
+        # check convergence statistic
+        @test maximum(abs.(1.0 .- rhat)) <= 0.01
+    end
+end


### PR DESCRIPTION
This PR cleans up the implementation of the Bayesian linear model and adds a generic framework for preprocessing the formula/data, inference, and postprocessing the results. It also adds a couple of simple test cases using toy datasets from `RDatasets`.

It might be good to come up with a somewhat more precise pattern for the `preprocess`, `inference`, and `postprocess` interface. We could also consider leaving preprocessing and postprocessing up to the user and having `blm` only perform inference.

I will also add that I am happy to help with further development and maintenance of this package!